### PR TITLE
Fixed typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# NavyWarefare
+# NavyWarfare
 IOS Game


### PR DESCRIPTION
Changed NavyWarefare to NavyWarfare in README as per Bryan's suggestion.
*note- Could not change name of repository to match for obvious reasons.
